### PR TITLE
driver: use proper class_create api based on kernel version

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -17,6 +17,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/vmalloc.h>
+#include <linux/version.h>
 #include <uapi/linux/fs.h>
 
 /**
@@ -921,7 +922,11 @@ int diagdev_init(void)
 		goto release_chrdev_region;
 	}
 
-	driver.cls = class_create(THIS_MODULE, "diag");
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+		driver.cls = class_create("diag");
+	#else
+		driver.cls = class_create(THIS_MODULE, "diag");
+	#endif
 	if (IS_ERR(driver.cls)) {
 		dev_crit(&pci_dev->dev, "unable to create driver class");
 		ret = err_ptr_to_code(driver.cls);


### PR DESCRIPTION
Introduced a conditional class_create() statement to handle different versions of the Linux kernel. Prior to version 6.4.0 the class_create() function required the THIS_MODULE argument, whereas version 6.4.0 and newer do not require it.

This modification allows code to work seamlessly across different kernel versions without introducing any potential issues.