### PR TITLE
makefile: Fix build and installation paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ uninstall:
 	-sudo rmmod $(TARGET)
 
 install: driver
-	sudo cp build/$(driver_module) $(KDIR)
+	sudo cp $(driver_module) $(KDIR)
 	sudo insmod $(KDIR)/$(driver_module)


### PR DESCRIPTION
This commit corrects the build and installation paths in the makefile for the diag_driver module. 'install' target copies the driver module from the current directory to the kernel modules directory.