### PR TITLE
Add MBL HW ID and increase max allocation count

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -3,7 +3,7 @@
 //  This file is provided under a dual BSD/GPLv2 license.  When using or
 //  redistributing this file, you may do so under either license.
 //
-//  Copyright(c) 2019-2023 Intel Corporation. All rights reserved.
+//  Copyright(c) 2019-2024 Intel Corporation. All rights reserved.
 //
 //  Author: Marcin Zielinski <marcinx.zielinski@linux.intel.com>
 //
@@ -39,6 +39,7 @@
  * @PCI_DEVICE_AUDIO_JSL: Jasper Lake
  * @PCI_DEVICE_AUDIO_ADL: Alder Lake
  * @PCI_DEVICE_AUDIO_RPL: Raptor Lake
+ * @PCI_DEVICE_AUDIO_MBL: Malibou Lake
  * @PCI_DEVICE_AUDIO_MTL: Meteor Lake
  * @PCI_DEVICE_AUDIO_LNL: Lunar Lake
  */
@@ -55,6 +56,7 @@ enum pci_device_id_e {
 	PCI_DEVICE_AUDIO_JSL = 0x38C8,
 	PCI_DEVICE_AUDIO_ADL = 0x51c8,
 	PCI_DEVICE_AUDIO_RPL = 0x51ca,
+	PCI_DEVICE_AUDIO_MBL = 0x51CE,
 	PCI_DEVICE_AUDIO_MTL = 0x7e28,
 	PCI_DEVICE_AUDIO_LNL = 0xA828,
 };
@@ -75,6 +77,7 @@ static const unsigned int device_ids[] = {
 	PCI_DEVICE_AUDIO_JSL,
 	PCI_DEVICE_AUDIO_ADL,
 	PCI_DEVICE_AUDIO_RPL,
+	PCI_DEVICE_AUDIO_MBL,
 	PCI_DEVICE_AUDIO_MTL,
 	PCI_DEVICE_AUDIO_LNL,
 };

--- a/driver.h
+++ b/driver.h
@@ -39,7 +39,7 @@ enum diag_dev_kind_t {
 /**
  * MAX_ALLOC_MAPS - Max allocations that can be performed on the driver.
  */
-#define MAX_ALLOC_MAPS 16
+#define MAX_ALLOC_MAPS 32
 
 /**
  * struct diag_mem_map_t - Map of allocations performed on the driver.


### PR DESCRIPTION
- add Malibou Lake HW ID 
- Increase the maximum allocation count for DMA operations to prevent exceeding the limit when all DMA channels are used simultaneously. 